### PR TITLE
Fix bug in diff detection when considering formatting

### DIFF
--- a/mule-reactor
+++ b/mule-reactor
@@ -280,6 +280,9 @@ def significant_changes?(updated_file,current_file,ignore_formatting,ignore_whit
         current_content = File.read(current_file)
         updated_content = File.read(updated_file)
       end
+    else
+      current_content = File.read(current_file)
+      updated_content = File.read(updated_file)
     end
 
 


### PR DESCRIPTION
The code did not read in the file content when option --ignore-formatting was ommited. This resulted in comparing empty string with empty string. This only showed when --ignore-whitespace and/or --ignore-blank-lines was used without --ignore-formatting.